### PR TITLE
add modifications to support ADOC functionality

### DIFF
--- a/ArchivalObjects.go
+++ b/ArchivalObjects.go
@@ -26,10 +26,16 @@ func (a *ASClient) GetArchivalObjectIDs(repositoryID int) ([]int, error) {
 
 func (a *ASClient) GetArchivalObject(repositoryId int, aoId int) (ArchivalObject, error) {
 
-	ao := ArchivalObject{}
-	endpoint := fmt.Sprintf("/repositories/%d/archival_objects/%d", repositoryId, aoId)
+	aoURI := fmt.Sprintf("/repositories/%d/archival_objects/%d", repositoryId, aoId)
 
-	reponse, err := a.get(endpoint, true)
+	return a.GetArchivalObjectFromURI(aoURI)
+}
+
+func (a *ASClient) GetArchivalObjectFromURI(aoURI string) (ArchivalObject, error) {
+
+	ao := ArchivalObject{}
+
+	reponse, err := a.get(aoURI, true)
 	if err != nil {
 		return ao, err
 	}

--- a/ArchivalObjects_test.go
+++ b/ArchivalObjects_test.go
@@ -31,7 +31,7 @@ func TestArchivalObject(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		} else {
-			t.Logf("Successfully requested and serialized archival %s: %s\n", ao.URI, ao.Title)
+			t.Logf("Successfully requested and serialized archival object %s: %s\n", ao.URI, ao.Title)
 		}
 	})
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+## CHANGELOG
+
+#### v0.6.0
+  - add `...FromURI()` functions:
+    - add `GetArchivalObjectFromURI()`
+    - add `GetDigitalObjectFromURI()`
+    - add `DeleteDigitalObjectFromURI()`
+    - add `GetDigitalObjectIDsForArchivalObjectFromURI()`
+  - refactor `...Object()` functions to use `...FromURI()` functions
+    - refactor `GetArchivalObject()` to use `GetArchivalObjectFromURI()`
+    - refactor `GetDigitalObject()` to use `GetDigitalObjectFromURI()`
+    - refactor `DeleteDigitalObject()` to use `DeleteDigitalObjectFromURI()`
+  - add helper type and function
+    - add `CreateOrUpdateResponse` type
+    - add `ParseCreateOrUpdateResponse()`
+  - force `bool` key/value pairs to always be sent in marshaled JSON for selected types
+    - remove `omitempty` option from `DigitalObject` type `bool` JSON tags
+    - remove `omitempty` option from `FileVersion` type `bool` JSON tags
+  
+

--- a/Common.go
+++ b/Common.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var LibraryVersion = "v0.3.14b"
+var LibraryVersion = "v0.6.0"
 
 var seed = rand.NewSource(time.Now().UnixNano())
 var rGen = rand.New(seed)

--- a/Common.go
+++ b/Common.go
@@ -114,3 +114,22 @@ func containsInt(list []int, id int) bool {
 	}
 	return false
 }
+
+type CreateResponse struct {
+	Status      string   `json:"status"`
+	Error       string   `json:"error"`
+	ID          int      `json:"id,omitempty"`
+	LockVersion int      `json:"lock_version,omitempty"`
+	Stale       bool     `json:"stale,omitempty"`
+	URI         string   `json:"uri,omitempty"`
+	Warnings    []string `json:"warnings,omitempty"`
+}
+
+func ParseCreateResponse(body string) *CreateResponse {
+	var createResponse CreateResponse
+	err := json.Unmarshal([]byte(body), &createResponse)
+	if err != nil {
+		return nil
+	}
+	return &createResponse
+}

--- a/Common.go
+++ b/Common.go
@@ -115,7 +115,7 @@ func containsInt(list []int, id int) bool {
 	return false
 }
 
-type CreateResponse struct {
+type CreateOrUpdateResponse struct {
 	Status      string   `json:"status"`
 	Error       string   `json:"error"`
 	ID          int      `json:"id,omitempty"`
@@ -125,11 +125,11 @@ type CreateResponse struct {
 	Warnings    []string `json:"warnings,omitempty"`
 }
 
-func ParseCreateResponse(body string) *CreateResponse {
-	var createResponse CreateResponse
-	err := json.Unmarshal([]byte(body), &createResponse)
+func ParseCreateOrUpdateResponse(body string) *CreateOrUpdateResponse {
+	var cour CreateOrUpdateResponse
+	err := json.Unmarshal([]byte(body), &cour)
 	if err != nil {
 		return nil
 	}
-	return &createResponse
+	return &cour
 }

--- a/Common_test.go
+++ b/Common_test.go
@@ -2,8 +2,10 @@ package aspace
 
 import (
 	"flag"
-	goaspacetest "github.com/nyudlts/go-aspace/goaspace_testing"
+	"strconv"
 	"testing"
+
+	goaspacetest "github.com/nyudlts/go-aspace/goaspace_testing"
 )
 
 func TestCommon(t *testing.T) {
@@ -33,4 +35,47 @@ func TestCommon(t *testing.T) {
 			t.Log("Succesfully requested valid session key.")
 		}
 	})
+
+	t.Run("Test ParseCreateResponse() Created", func(t *testing.T) {
+
+		responseBody := `{"status":"Created","id":61344,"lock_version":0,"stale":true,"uri":"/repositories/6/digital_objects/61344","warnings":[]}`
+		got := ParseCreateResponse(responseBody)
+
+		scenarios := [][]string{
+			{"Created", got.Status, "Incorrect Status"},
+			{"", got.Error, "Incorrect Error"},
+			{"61344", strconv.FormatInt(int64(got.ID), 10), "Incorrect ID"},
+			{"0", strconv.FormatInt(int64(got.LockVersion), 10), "Incorrect LockVersion"},
+			{"true", strconv.FormatBool(got.Stale), "Incorrect Stale"},
+			{"/repositories/6/digital_objects/61344", got.URI, "Incorrect URI"},
+		}
+
+		for _, scenario := range scenarios {
+			if scenario[1] != scenario[0] {
+				t.Errorf("unexpected result: %s: want: '%s', got: '%s'", scenario[2], scenario[0], scenario[1])
+			}
+		}
+	})
+
+	t.Run("Test ParseCreateResponse() Error", func(t *testing.T) {
+
+		responseBody := `{"error":"I need more coffee!"}`
+		got := ParseCreateResponse(responseBody)
+
+		scenarios := [][]string{
+			{"", got.Status, "Incorrect Status"},
+			{"I need more coffee!", got.Error, "Incorrect Error"},
+			{"0", strconv.FormatInt(int64(got.ID), 10), "Incorrect ID"},
+			{"0", strconv.FormatInt(int64(got.LockVersion), 10), "Incorrect LockVersion"},
+			{"false", strconv.FormatBool(got.Stale), "Incorrect Stale"},
+			{"", got.URI, "Incorrect URI"},
+		}
+
+		for _, scenario := range scenarios {
+			if scenario[1] != scenario[0] {
+				t.Errorf("unexpected result: %s: want: '%s', got: '%s'", scenario[2], scenario[0], scenario[1])
+			}
+		}
+	})
+
 }

--- a/Common_test.go
+++ b/Common_test.go
@@ -36,10 +36,10 @@ func TestCommon(t *testing.T) {
 		}
 	})
 
-	t.Run("Test ParseCreateResponse() Created", func(t *testing.T) {
+	t.Run("Test ParseCreateOrUpdateResponse() Created", func(t *testing.T) {
 
 		responseBody := `{"status":"Created","id":61344,"lock_version":0,"stale":true,"uri":"/repositories/6/digital_objects/61344","warnings":[]}`
-		got := ParseCreateResponse(responseBody)
+		got := ParseCreateOrUpdateResponse(responseBody)
 
 		scenarios := [][]string{
 			{"Created", got.Status, "Incorrect Status"},
@@ -57,10 +57,10 @@ func TestCommon(t *testing.T) {
 		}
 	})
 
-	t.Run("Test ParseCreateResponse() Error", func(t *testing.T) {
+	t.Run("Test ParseCreateOrUpdateResponse() Error", func(t *testing.T) {
 
 		responseBody := `{"error":"I need more coffee!"}`
-		got := ParseCreateResponse(responseBody)
+		got := ParseCreateOrUpdateResponse(responseBody)
 
 		scenarios := [][]string{
 			{"", got.Status, "Incorrect Status"},

--- a/DigitalObjects.go
+++ b/DigitalObjects.go
@@ -130,7 +130,7 @@ func (a *ASClient) GetDigitalObjectIDsForResource(repositoryId int, resourceId i
 
 		for _, instance := range ao.Instances {
 			if instance.InstanceType == "digital_object" {
-				doURIs = append(doURIs, instance.DigitalObject["ref"])
+				doURIs = append(doURIs, instance.DigitalObject.URI)
 			}
 		}
 	}

--- a/DigitalObjects.go
+++ b/DigitalObjects.go
@@ -85,8 +85,13 @@ func (a *ASClient) CreateDigitalObject(repositoryId int, dao DigitalObject) (str
 }
 
 func (a *ASClient) DeleteDigitalObject(repositoryId int, doId int) (string, error) {
-	endpoint := fmt.Sprintf("/repositories/%d/digital_objects/%d", repositoryId, doId)
-	response, err := a.delete(endpoint)
+	doURI := fmt.Sprintf("/repositories/%d/digital_objects/%d", repositoryId, doId)
+
+	return a.DeleteDigitalObjectFromURI(doURI)
+}
+
+func (a *ASClient) DeleteDigitalObjectFromURI(doURI string) (string, error) {
+	response, err := a.delete(doURI)
 	if err != nil {
 		return "", err
 	}

--- a/DigitalObjects.go
+++ b/DigitalObjects.go
@@ -130,7 +130,7 @@ func (a *ASClient) GetDigitalObjectIDsForResource(repositoryId int, resourceId i
 
 		for _, instance := range ao.Instances {
 			if instance.InstanceType == "digital_object" {
-				doURIs = append(doURIs, instance.DigitalObject.URI)
+				doURIs = append(doURIs, instance.DigitalObject["ref"])
 			}
 		}
 	}
@@ -144,4 +144,21 @@ func (do DigitalObject) ContainsUseStatement(role string) bool {
 		}
 	}
 	return false
+}
+
+func (a *ASClient) GetDigitalObjectIDsForArchivalObjectFromURI(aoURI string) ([]string, error) {
+	doURIs := []string{}
+
+	ao, err := a.GetArchivalObjectFromURI(aoURI)
+	if err != nil {
+		return doURIs, err
+	}
+
+	for _, instance := range ao.Instances {
+		if instance.InstanceType == "digital_object" {
+			doURIs = append(doURIs, instance.DigitalObject["ref"])
+		}
+	}
+
+	return doURIs, nil
 }

--- a/DigitalObjects.go
+++ b/DigitalObjects.go
@@ -41,6 +41,24 @@ func (a *ASClient) GetDigitalObject(repositoryId int, daoId int) (DigitalObject,
 	return do, nil
 }
 
+func (a *ASClient) GetDigitalObjectFromURI(doURI string) (DigitalObject, error) {
+	do := DigitalObject{}
+	response, err := a.get(doURI, true)
+	if err != nil {
+		return do, err
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return do, err
+	}
+	err = json.Unmarshal(body, &do)
+	if err != nil {
+		return do, err
+	}
+
+	return do, nil
+}
+
 func (a *ASClient) UpdateDigitalObject(repositoryId int, daoId int, dao DigitalObject) (string, error) {
 	endpoint := fmt.Sprintf("/repositories/%d/digital_objects/%d", repositoryId, daoId)
 	body, err := json.Marshal(dao)

--- a/DigitalObjects.go
+++ b/DigitalObjects.go
@@ -23,22 +23,9 @@ func (a *ASClient) GetDigitalObjectIDs(repositoryId int) ([]int, error) {
 }
 
 func (a *ASClient) GetDigitalObject(repositoryId int, daoId int) (DigitalObject, error) {
-	do := DigitalObject{}
-	endpoint := fmt.Sprintf("/repositories/%d/digital_objects/%d", repositoryId, daoId)
-	response, err := a.get(endpoint, true)
-	if err != nil {
-		return do, err
-	}
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return do, err
-	}
-	err = json.Unmarshal(body, &do)
-	if err != nil {
-		return do, err
-	}
+	doURI := fmt.Sprintf("/repositories/%d/digital_objects/%d", repositoryId, daoId)
 
-	return do, nil
+	return a.GetDigitalObjectFromURI(doURI)
 }
 
 func (a *ASClient) GetDigitalObjectFromURI(doURI string) (DigitalObject, error) {

--- a/DigitalObjects_test.go
+++ b/DigitalObjects_test.go
@@ -2,7 +2,6 @@ package aspace
 
 import (
 	"flag"
-	"fmt"
 	"slices"
 	"testing"
 
@@ -20,13 +19,14 @@ func TestDigitalObject(t *testing.T) {
 		repositoryID, digitalObjectID, err := client.GetRandomDigitalObject()
 		if err != nil {
 			t.Error(err)
+			t.FailNow()
 		}
 
 		do, err := client.GetDigitalObject(repositoryID, digitalObjectID)
 		if err != nil {
 			t.Error(err)
 		} else {
-			t.Log(fmt.Sprintf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title))
+			t.Logf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title)
 		}
 	})
 
@@ -37,7 +37,7 @@ func TestDigitalObject(t *testing.T) {
 			t.Error(err)
 		} else {
 			t.Log(do.Notes)
-			t.Log(fmt.Sprintf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title))
+			t.Logf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title)
 		}
 	})
 

--- a/DigitalObjects_test.go
+++ b/DigitalObjects_test.go
@@ -3,8 +3,10 @@ package aspace
 import (
 	"flag"
 	"fmt"
-	goaspacetest "github.com/nyudlts/go-aspace/goaspace_testing"
+	"slices"
 	"testing"
+
+	goaspacetest "github.com/nyudlts/go-aspace/goaspace_testing"
 )
 
 func TestDigitalObject(t *testing.T) {
@@ -37,5 +39,33 @@ func TestDigitalObject(t *testing.T) {
 			t.Log(do.Notes)
 			t.Log(fmt.Sprintf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title))
 		}
+	})
+
+	t.Run("Test DigitalObjectIDs from an ArchivalObject", func(t *testing.T) {
+
+		aoURI := "/repositories/3/archival_objects/912180"
+
+		got, err := client.GetDigitalObjectIDsForArchivalObjectFromURI(aoURI)
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+
+		want := []string{"/repositories/3/digital_objects/45716", "/repositories/3/digital_objects/45726", "/repositories/3/digital_objects/45717"}
+		if len(want) != len(got) {
+			t.Errorf("expected %d digital objects but got %d", len(want), len(got))
+			t.FailNow()
+		}
+
+		slices.Sort(want)
+		slices.Sort(got)
+
+		for i, w := range want {
+			if w != got[i] {
+				t.Errorf("expected %s but got %s", w, got[i])
+				t.FailNow()
+			}
+		}
+		t.Logf("Successfully retrieved DigitalObjectIDs for archival object: %s\n", aoURI)
 	})
 }

--- a/DigitalObjects_test.go
+++ b/DigitalObjects_test.go
@@ -25,12 +25,30 @@ func TestDigitalObject(t *testing.T) {
 		do, err := client.GetDigitalObject(repositoryID, digitalObjectID)
 		if err != nil {
 			t.Error(err)
+			t.FailNow()
 		} else {
 			t.Logf("Successfully requested and serialized digital object %s %s\n", do.URI, do.Title)
 		}
+
 	})
 
-	t.Run("Test Unamarshal a digital object with notes", func(t *testing.T) {
+	t.Run("Test serialize a digital object using doURI", func(t *testing.T) {
+		doURI := "/repositories/3/digital_objects/45726"
+		do, err := client.GetDigitalObjectFromURI(doURI)
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+
+		want := "MSS_407_cuid29413B"
+		if do.DigitalObjectID != want {
+			t.Errorf("Expected %s but got %s", want, do.DigitalObjectID)
+			t.FailNow()
+		}
+		t.Logf("Successfully requested and serialized digital object via doURI %s %s\n", do.URI, do.Title)
+	})
+
+	t.Run("Test Unmarshal a digital object with notes", func(t *testing.T) {
 
 		do, err := client.GetDigitalObject(2, 261)
 		if err != nil {

--- a/Models.go
+++ b/Models.go
@@ -270,7 +270,7 @@ type FileVersion struct {
 	Identifier            string `json:"identifier,omitempty"`
 	LockVersion           int    `json:"lock_version,omitempty"`
 	FileURI               string `json:"file_uri,omitempty"`
-	Publish               bool   `json:"publish,omitempty"`
+	Publish               bool   `json:"publish"`
 	FileFormatVersion     string `json:"file_format_version,omitempty"`
 	FileSizeBytes         uint64 `json:"file_size_bytes,omitempty"`
 	Checksum              string `json:"checksum,omitempty"`
@@ -281,7 +281,7 @@ type FileVersion struct {
 	XLinkShowAttribute    string `json:"xlink_show_attribute,omitempty"`
 	FileFormatName        string `json:"file_format_name,omitempty"`
 	JSONModelType         string `json:"jsonmodel_type,omitempty"`
-	IsRepresentative      bool   `json:"is_representative,omitempty"`
+	IsRepresentative      bool   `json:"is_representative"`
 }
 
 type Instance struct {

--- a/Models.go
+++ b/Models.go
@@ -187,7 +187,7 @@ type Deaccession struct {
 	Scope         string   `json:"scope,omitempty"`
 	Description   string   `json:"description,omitempty"`
 	Date          Date     `json:"date,omitempty"`
-	Reason        string   `json:"reason,omitempty,omitempty"`
+	Reason        string   `json:"reason,omitempty"`
 	Disposition   string   `json:"disposition,omitempty"`
 	Notification  bool     `json:"notification,omitempty"`
 	Extents       []Extent `json:"extents,omitempty"`
@@ -285,11 +285,11 @@ type FileVersion struct {
 }
 
 type Instance struct {
-	InstanceType     string        `json:"instance_type,omitempty"`
-	SubContainer     SubContainer  `json:"sub_container,omitempty"`
-	DigitalObject    DigitalObject `json:"digital_object,omitempty"`
-	IsRepresentative bool          `json:"is_representative,omitempty"`
-	JSONModelType    string        `json:"jsonmodel_type,omitempty"`
+	InstanceType     string            `json:"instance_type,omitempty"`
+	SubContainer     SubContainer      `json:"sub_container,omitempty"`
+	DigitalObject    map[string]string `json:"digital_object,omitempty"`
+	IsRepresentative bool              `json:"is_representative,omitempty"`
+	JSONModelType    string            `json:"jsonmodel_type,omitempty"`
 }
 
 type Inherited struct {

--- a/Models.go
+++ b/Models.go
@@ -198,10 +198,10 @@ type DigitalObject struct {
 	LockVersion          *int                   `json:"lock_version,omitempty"`
 	DigitalObjectID      string                 `json:"digital_object_id,omitempty"`
 	Title                string                 `json:"title,omitempty"`
-	Publish              bool                   `json:"publish,omitempty"`
-	Restrictions         bool                   `json:"restrictions,omitempty"`
-	Suppressed           bool                   `json:"suppressed,omitempty"`
-	IsSlugAuto           bool                   `json:"is_slug_auto,omitempty"`
+	Publish              bool                   `json:"publish"`
+	Restrictions         bool                   `json:"restrictions"`
+	Suppressed           bool                   `json:"suppressed"`
+	IsSlugAuto           bool                   `json:"is_slug_auto"`
 	JSONModelType        string                 `json:"jsonmodel_type,omitempty"`
 	ExternalIds          []ExternalID           `json:"external_ids,omitempty"`
 	Subjects             []SubjectReference     `json:"subjects,omitempty"`

--- a/Models.go
+++ b/Models.go
@@ -285,11 +285,11 @@ type FileVersion struct {
 }
 
 type Instance struct {
-	InstanceType     string            `json:"instance_type,omitempty"`
-	SubContainer     SubContainer      `json:"sub_container,omitempty"`
-	DigitalObject    map[string]string `json:"digital_object,omitempty"`
-	IsRepresentative bool              `json:"is_representative,omitempty"`
-	JSONModelType    string            `json:"jsonmodel_type,omitempty"`
+	InstanceType     string        `json:"instance_type,omitempty"`
+	SubContainer     SubContainer  `json:"sub_container,omitempty"`
+	DigitalObject    DigitalObject `json:"digital_object,omitempty"`
+	IsRepresentative bool          `json:"is_representative,omitempty"`
+	JSONModelType    string        `json:"jsonmodel_type,omitempty"`
 }
 
 type Inherited struct {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-aspace v0.3.14b
+# go-aspace v0.6.0
 a Go library for ArchivesSpace integrations
 
 ## Use


### PR DESCRIPTION
## Overview
Make modifications to support the Automated Digital Object Creation (ADOC) project.

**Details:**
  - add `...FromURI()` functions:
    - add `GetArchivalObjectFromURI()`
    - add `GetDigitalObjectFromURI()`
    - add `DeleteDigitalObjectFromURI()`
    - add `GetDigitalObjectIDsForArchivalObjectFromURI()`
  - refactor `...Object()` functions to use `...FromURI()` functions
    - refactor `GetArchivalObject()` to use `GetArchivalObjectFromURI()`
    - refactor `GetDigitalObject()` to use `GetDigitalObjectFromURI()`
    - refactor `DeleteDigitalObject()` to use `DeleteDigitalObjectFromURI()`
  - add helper type and function
    - add `CreateOrUpdateResponse` type
    - add `ParseCreateOrUpdateResponse()`
  - force `bool` key/value pairs to always be sent in marshaled JSON for selected types
    - remove `omitempty` option from `DigitalObject` type `bool` JSON tags
    - remove `omitempty` option from `FileVersion` type `bool` JSON tags
  - add `CHANGELOG.md` file
  - bump version to `v0.6.0`
