### PR TITLE
bugfix/tweak workorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+#### v0.6.1
+  - bug fix: rewrite `func (wor WorkOrderRow) String()` to use
+    `encoding/csv` to handle string escapes
+  
 #### v0.6.0
   - add `...FromURI()` functions:
     - add `GetArchivalObjectFromURI()`

--- a/Common.go
+++ b/Common.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var LibraryVersion = "v0.6.0"
+var LibraryVersion = "v0.6.1"
 
 var seed = rand.NewSource(time.Now().UnixNano())
 var rGen = rand.New(seed)

--- a/Models.go
+++ b/Models.go
@@ -433,7 +433,7 @@ type NoteText struct {
 	JSONModelType string `json:"jsonmodel_type,omitempty"`
 	Content       string `json:"content,omitempty"`
 	Publish       bool   `json:"publish,omitempty"`
-	Title         string `json:"title,omitEmpty"`
+	Title         string `json:"title,omitempty"`
 }
 
 type RelatedAgent struct {

--- a/WorkOrder.go
+++ b/WorkOrder.go
@@ -23,11 +23,6 @@ type WorkOrderRow struct {
 	fields []string
 }
 
-// convert a work order row into a tab-delimited string
-//func (wor WorkOrderRow) String() string {
-//	return strings.Join(wor.fields, "\t")
-//}
-
 func (wor WorkOrderRow) String() string {
 	var b bytes.Buffer
 	out := csv.NewWriter(bufio.NewWriter(&b))

--- a/WorkOrder.go
+++ b/WorkOrder.go
@@ -1,6 +1,8 @@
 package aspace
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -21,9 +23,19 @@ type WorkOrderRow struct {
 	fields []string
 }
 
-// convert a work order row into a tabe delimited string
+// convert a work order row into a tab-delimited string
+//func (wor WorkOrderRow) String() string {
+//	return strings.Join(wor.fields, "\t")
+//}
+
 func (wor WorkOrderRow) String() string {
-	return strings.Join(wor.fields, "\t")
+	var b bytes.Buffer
+	out := csv.NewWriter(bufio.NewWriter(&b))
+	out.Comma = '\t'
+	out.Write(wor.fields)
+	out.Flush()
+	// the csv writer adds a newline, so we need to trim it
+	return strings.Trim(b.String(), "\n")
 }
 
 // assertHeaderFields ensures that the fields in the the work order being processed match expectations

--- a/WorkOrder_test.go
+++ b/WorkOrder_test.go
@@ -9,12 +9,6 @@ import (
 
 const fixtureRoot = "./goaspace_testing/testdata"
 
-func assertStringsEqual(want, got string, t *testing.T) {
-	if want != got {
-		t.Errorf("want: %s , got: %s", want, got)
-	}
-}
-
 func createAndLoadWorkOrder(path string, t *testing.T) *WorkOrder {
 	var wo WorkOrder
 

--- a/WorkOrder_test.go
+++ b/WorkOrder_test.go
@@ -107,6 +107,8 @@ func TestWorkOrderRowString(t *testing.T) {
 	}
 
 	scenarios := [][]string{
+		{`TAM.105	7245198c4f6a94511db03f887ff37b25	/repositories/2/archival_objects/990834	80	5		Events and Programs -- Summer School	TW_TAM_105_ER_75`, sut.Rows[0].String(), "Incorrect Work Order Row String"},
+		{`TAM.105	1736fdb9380996e9242697b69126e48a	/repositories/2/archival_objects/992007				"Posters -- ""Turning the Tide Towards Freedom"""	TW_TAM_105_ER_51`, sut.Rows[1].String(), "Incorrect Work Order Row String"},
 		{`TAM.105	9f96bb2de3cdd56860279c1b7063aad3	/repositories/2/archival_objects/992008				"Conventions -- ""Life After Bush"""	TW_TAM_105_ER_45`, sut.Rows[2].String(), "Incorrect Work Order Row String"},
 	}
 

--- a/WorkOrder_test.go
+++ b/WorkOrder_test.go
@@ -30,6 +30,24 @@ func createAndLoadWorkOrder(path string, t *testing.T) *WorkOrder {
 	return &wo
 }
 
+func createAndLoadWorkOrderReturnError(path string, t *testing.T) (*WorkOrder, error) {
+	var wo WorkOrder
+
+	r, err := os.Open(path)
+	if err != nil {
+		t.Errorf("problem opening %s", path)
+	}
+	defer r.Close()
+
+	// note: intentionally ignoring any error here
+	err = wo.Load(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wo, nil
+}
+
 //------------------------------------------------------------------------------
 // begin tests
 //------------------------------------------------------------------------------
@@ -78,6 +96,29 @@ func TestWorkOrderRowAccessors(t *testing.T) {
 	for _, scenario := range scenarios {
 		if scenario[wantIdx] != scenario[gotIdx] {
 			t.Errorf("unexpected result: %s: want: '%s', got: '%s'", scenario[msgIdx], scenario[wantIdx], scenario[gotIdx])
+		}
+	}
+}
+
+func TestWorkOrderRowString(t *testing.T) {
+	const (
+		wantIdx = 0
+		gotIdx  = 1
+		msgIdx  = 2
+	)
+
+	sut, err := createAndLoadWorkOrderReturnError(filepath.Join(fixtureRoot, "aspace_work_order_report_tam_105.tsv"), t)
+	if err != nil {
+		t.Error(err)
+	}
+
+	scenarios := [][]string{
+		{`TAM.105	9f96bb2de3cdd56860279c1b7063aad3	/repositories/2/archival_objects/992008				"Conventions -- ""Life After Bush"""	TW_TAM_105_ER_45`, sut.Rows[2].String(), "Incorrect Work Order Row String"},
+	}
+
+	for _, scenario := range scenarios {
+		if scenario[wantIdx] != scenario[gotIdx] {
+			t.Errorf("unexpected result: %s: \nwant: '%s' \ngot : '%s'", scenario[msgIdx], scenario[wantIdx], scenario[gotIdx])
 		}
 	}
 }

--- a/WorkOrder_test.go
+++ b/WorkOrder_test.go
@@ -55,82 +55,30 @@ func TestHeader(t *testing.T) {
 	}
 }
 
-func TestGetResourceID(t *testing.T) {
-	var want, got string
+func TestScenarios(t *testing.T) {
+	const (
+		wantIdx = 0
+		gotIdx  = 1
+		msgIdx  = 2
+	)
 
 	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
 
-	want = "DLTS.2022"
-	got = sut.Rows[1].GetResourceID()
-	assertStringsEqual(want, got, t)
-}
+	scenarios := [][]string{
+		{"DLTS.2022", sut.Rows[1].GetResourceID(), "Incorrect Resource ID"},
+		{"4a6f56d2b69962a05792478cae78e888", sut.Rows[2].GetRefID(), "Incorrect Ref ID"},
+		{"/repositories/3/archival_objects/979520", sut.Rows[0].GetURI(), "Incorrect URI"},
+		{"V01", sut.Rows[1].GetContainerIndicator1(), "Incorrect Container Indicator 1"},
+		{"I02", sut.Rows[2].GetContainerIndicator2(), "Incorrect Container Indicator 2"},
+		{"A03", sut.Rows[0].GetContainerIndicator3(), "Incorrect Container Indicator 3"},
+		{"Video Test", sut.Rows[1].GetTitle(), "Incorrect Title"},
+		{"cuid39671", sut.Rows[2].GetComponentID(), "Incorrect Component ID"},
+	}
 
-func TestGetRefID(t *testing.T) {
-	var want, got string
+	for _, scenario := range scenarios {
+		if scenario[wantIdx] != scenario[gotIdx] {
+			t.Errorf("unexpected result: %s: want: '%s', got: '%s'", scenario[msgIdx], scenario[wantIdx], scenario[gotIdx])
+		}
+	}
 
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "4a6f56d2b69962a05792478cae78e888"
-	got = sut.Rows[2].GetRefID()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetURI(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "/repositories/3/archival_objects/979520"
-	got = sut.Rows[0].GetURI()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetContainerIndicator1(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "V01"
-	got = sut.Rows[1].GetContainerIndicator1()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetContainerIndicator2(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "I02"
-	got = sut.Rows[2].GetContainerIndicator2()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetContainerIndicator3(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "A03"
-	got = sut.Rows[0].GetContainerIndicator3()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetContainerTitle(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "Video Test"
-	got = sut.Rows[1].GetTitle()
-	assertStringsEqual(want, got, t)
-}
-
-func TestGetComponentID(t *testing.T) {
-	var want, got string
-
-	sut := createAndLoadWorkOrder(filepath.Join(fixtureRoot, "valid_wo.tsv"), t)
-
-	want = "cuid39671"
-	got = sut.Rows[2].GetComponentID()
-	assertStringsEqual(want, got, t)
 }

--- a/WorkOrder_test.go
+++ b/WorkOrder_test.go
@@ -55,7 +55,7 @@ func TestHeader(t *testing.T) {
 	}
 }
 
-func TestScenarios(t *testing.T) {
+func TestWorkOrderRowAccessors(t *testing.T) {
 	const (
 		wantIdx = 0
 		gotIdx  = 1
@@ -80,5 +80,4 @@ func TestScenarios(t *testing.T) {
 			t.Errorf("unexpected result: %s: want: '%s', got: '%s'", scenario[msgIdx], scenario[wantIdx], scenario[gotIdx])
 		}
 	}
-
 }

--- a/goaspace_testing/testdata/aspace_work_order_report_tam_105.tsv
+++ b/goaspace_testing/testdata/aspace_work_order_report_tam_105.tsv
@@ -1,0 +1,7 @@
+Resource ID	Ref ID	URI	Container Indicator 1	Container Indicator 2	Container Indicator 3	Title	Component ID
+TAM.105	7245198c4f6a94511db03f887ff37b25	/repositories/2/archival_objects/990834	80	5	""	Events and Programs -- Summer School	TW_TAM_105_ER_75
+TAM.105	1736fdb9380996e9242697b69126e48a	/repositories/2/archival_objects/992007	""	""	""	"Posters -- ""Turning the Tide Towards Freedom"""	TW_TAM_105_ER_51
+TAM.105	9f96bb2de3cdd56860279c1b7063aad3	/repositories/2/archival_objects/992008	""	""	""	"Conventions -- ""Life After Bush"""	TW_TAM_105_ER_45
+TAM.105	7690f21d8cf49dbaaf6fefd0146c9e42	/repositories/2/archival_objects/992009	""	""	""	"Conventions -- ""The Fightback"""	TW_TAM_105_ER_47
+TAM.105	87f446d4cf757e0d12a57bf0c9c14e39	/repositories/2/archival_objects/992010	""	""	""	"Conventions -- ""When Bush Comes to Shove"""	TW_TAM_105_ER_46
+TAM.105	fb7c98c2086deacc1328587ca68fecf5	/repositories/2/archival_objects/992011	""	""	""	Events and Programs -- Summer Study Group	TW_TAM_105_ER_57


### PR DESCRIPTION
## Overview:

* Modify the `func (wor WorkOrderRow) String()` function to use the `encoding/csv` package
* Bump package version to `v0.6.1`
* Perform minor cleanup (refactor tests, fix a typo)
