### PR TITLE
feature/rstar 755

### DIFF
--- a/ASClient.go
+++ b/ASClient.go
@@ -42,6 +42,13 @@ func NewClient(configFile string, environment string, timeout int) (*ASClient, e
 		return client, err
 	}
 
+	return NewClientFromCreds(creds, timeout)
+}
+
+func NewClientFromCreds(creds Creds, timeout int) (*ASClient, error) {
+
+	var client *ASClient
+
 	log.Printf("[DEBUG] url: %s, username: %s, password: %s", creds.URL, creds.Username, creds.Password)
 
 	tr := &http.Transport{
@@ -95,7 +102,7 @@ func getSessionKey(creds Creds) (string, error) {
 	}
 
 	if response.StatusCode != 200 {
-		return "", fmt.Errorf("Did not return a 200 while authenticating, recieved a %d", response.StatusCode)
+		return "", fmt.Errorf("Did not return a 200 while authenticating, received a %d", response.StatusCode)
 	}
 
 	body, err := io.ReadAll(response.Body)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+#### v0.7.0
+  - add `func (a *ASClient) FindArchivalObjectsByID(...)([]string, error)`  
+    that allows you to look up archival objects by the `ref_id` or `component_id` fields
+  
 #### v0.6.1
   - bug fix: rewrite `func (wor WorkOrderRow) String()` to use
     `encoding/csv` to handle string escapes

--- a/Common.go
+++ b/Common.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var LibraryVersion = "v0.6.1"
+var LibraryVersion = "v0.7.0"
 
 var seed = rand.NewSource(time.Now().UnixNano())
 var rGen = rand.New(seed)

--- a/FindByID.go
+++ b/FindByID.go
@@ -1,0 +1,67 @@
+package aspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+)
+
+type FindArchivalObjectsByIDRefs struct {
+	Ref string `json:"ref"`
+}
+type FindArchivalObjectsByIDResults struct {
+	ArchivalObjects []FindArchivalObjectsByIDRefs `json:"archival_objects"`
+}
+
+// FindArchivalObjectsByID returns a slice of archival_object_uri strings if
+// the id is found, and an empty slice if the id is not found.
+//
+// Acceptable idTypes are "refID" and "componentID".
+//
+// The id string will be automatically URL encoded but will not be otherwise transformed
+// e.g., ID: 231.0176 -->  ID%3A%20231.0176
+//
+// This code uses the ASpace "find_by_id" API endpoint described here:
+// https://archivesspace.github.io/archivesspace/api/#find-archival-objects-by-ref_id-or-component_id
+func (a *ASClient) FindArchivalObjectsByID(repositoryId int, id string, idType string) ([]string, error) {
+
+	aoURIs := []string{}
+	// The URL encoding is necessary because the id string will be passed as a query parameter
+	id = url.QueryEscape(id)
+
+	idTypeFragment := ""
+	switch idType {
+	case "refID":
+		idTypeFragment = "ref_id"
+	case "componentID":
+		idTypeFragment = "component_id"
+	default:
+		return aoURIs, fmt.Errorf("idType must be 'refID' or 'componentID'")
+	}
+
+	// Example URL from the documentation:
+	// /repositories/:repo_id:/find_by_id/archival_objects?component_id[]=hello_im_a_component_id;resolve[]=archival_objects
+	endpoint := fmt.Sprintf(`/repositories/%d/find_by_id/archival_objects?%s[]=%s`, repositoryId, idTypeFragment, id)
+	response, err := a.get(endpoint, true)
+	if err != nil {
+		return aoURIs, err
+	}
+	body := response.Body
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return aoURIs, err
+	}
+
+	response.Body.Close()
+	results := FindArchivalObjectsByIDResults{}
+	err = json.Unmarshal(bodyBytes, &results)
+	if err != nil {
+		return aoURIs, err
+	}
+
+	for _, ao := range results.ArchivalObjects {
+		aoURIs = append(aoURIs, ao.Ref)
+	}
+	return aoURIs, nil
+}

--- a/FindByID_test.go
+++ b/FindByID_test.go
@@ -1,5 +1,9 @@
+// This file contains tests for the FindByID function in the aspace package.
+// All tests are currently commented out because the tests rely on a running ArchivesSpace instance
+// with a known set of data.
 package aspace
 
+/*
 import (
 	"flag"
 	"testing"
@@ -152,3 +156,4 @@ func TestFindByComponentIDNoResults(t *testing.T) {
 		}
 	})
 }
+*/

--- a/FindByID_test.go
+++ b/FindByID_test.go
@@ -1,0 +1,154 @@
+package aspace
+
+import (
+	"flag"
+	"testing"
+
+	goaspacetest "github.com/nyudlts/go-aspace/goaspace_testing"
+)
+
+func TestFindByIdRefIDSingleResult(t *testing.T) {
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test known archival object by refID", func(t *testing.T) {
+		resp, err := client.FindArchivalObjectsByID(3, "ref9000", "refID")
+		if err != nil {
+			t.Error(t)
+		}
+
+		want := "/repositories/3/archival_objects/566184"
+		if len(resp) != 1 {
+			t.Errorf("got %d, want 1", len(resp))
+		} else {
+			if resp[0] != want {
+				t.Errorf("got %s, want %s", resp[0], want)
+			}
+		}
+	})
+}
+
+func TestFindByIdComponentIDSingleResult(t *testing.T) {
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test known archival object by componentID", func(t *testing.T) {
+		resp, err := client.FindArchivalObjectsByID(3, "cuid12772", "componentID")
+		if err != nil {
+			t.Error(t)
+		}
+
+		want := "/repositories/3/archival_objects/566184"
+		if len(resp) != 1 {
+			t.Errorf("got %d, want 1", len(resp))
+		} else {
+			if resp[0] != want {
+				t.Errorf("got %s, want %s", resp[0], want)
+			}
+		}
+	})
+}
+
+func TestFindByIdRefIDMultipleResults(t *testing.T) {
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test known multiple archival objects by refID", func(t *testing.T) {
+		resp, err := client.FindArchivalObjectsByID(3, "ref5000", "refID")
+		if err != nil {
+			t.Error(t)
+		}
+
+		want := []string{
+			"/repositories/3/archival_objects/470159",
+			"/repositories/3/archival_objects/476961",
+			"/repositories/3/archival_objects/511924",
+			"/repositories/3/archival_objects/518940",
+			"/repositories/3/archival_objects/546854",
+			"/repositories/3/archival_objects/568398",
+		}
+		if len(resp) != len(want) {
+			t.Errorf("got %d, want %d", len(resp), len(want))
+		} else {
+			for i := range resp {
+				if resp[i] != want[i] {
+					t.Errorf("got %s, want %s", resp[i], want[i])
+				}
+			}
+		}
+	})
+}
+
+func TestFindByIdBadIDType(t *testing.T) {
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test bad IDType", func(t *testing.T) {
+		_, err := client.FindArchivalObjectsByID(3, "blah", "potato-muffins")
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+
+		want := "idType must be 'refID' or 'componentID'"
+		if err.Error() != want {
+			t.Errorf("got %s, want %s", err.Error(), want)
+		}
+	})
+}
+
+func TestFindByComponentIDMediaIDSingleResult(t *testing.T) {
+
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test known archival object by componentID with media ID string", func(t *testing.T) {
+		resp, err := client.FindArchivalObjectsByID(3, "ID: 213.0176", "componentID")
+		if err != nil {
+			t.Error(t)
+		}
+
+		want := "/repositories/3/archival_objects/513548"
+		if len(resp) != 1 {
+			t.Errorf("got %d, want 1", len(resp))
+		} else {
+			if resp[0] != want {
+				t.Errorf("got %s, want %s", resp[0], want)
+			}
+		}
+	})
+}
+
+func TestFindByComponentIDNoResults(t *testing.T) {
+
+	flag.Parse()
+	client, err := NewClient(goaspacetest.Config, goaspacetest.Environment, 20)
+	if err != nil {
+		t.Error(t)
+	}
+
+	t.Run("Test unknown archival object by componentID", func(t *testing.T) {
+		resp, err := client.FindArchivalObjectsByID(3, "63a006bc-c059-49fb-a8b0-1cadc4940305", "componentID")
+		if err != nil {
+			t.Error(t)
+		}
+
+		if len(resp) != 0 {
+			t.Errorf("got %d, want 0", len(resp))
+		}
+	})
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dev:
   password: your-password
   
 local:
-  url: https:/localhost:8089
+  url: http://localhost:8089
   username: your-username
   password: your-password
 ```


### PR DESCRIPTION
## Overview
#### v0.7.0
  - add `func (a *ASClient) FindArchivalObjectsByID(...)([]string, error)`
    that allows you to look up archival objects by the `ref_id` or `component_id` fields

